### PR TITLE
Made the text rendering polygon face front facing

### DIFF
--- a/font.go
+++ b/font.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/go-gl/gl/all-core/gl"
+	"github.com/go-gl/gl/v4.1-core/gl"
 )
 
 // Direction represents the direction in which strings should be rendered.
@@ -120,7 +120,7 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		w := float32(ch.width) * scale
 		h := float32(ch.height) * scale
 		vertices := []float32{
-			xpos + w, yPos, 1.0, 0.0,
+			xpos + w, ypos, 1.0, 0.0,
 			xpos, ypos, 0.0, 0.0,
 			xpos, ypos + h, 0.0, 1.0,
 
@@ -137,7 +137,7 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		//BufferSubData(target Enum, offset int, data []byte)
 		gl.BufferSubData(gl.ARRAY_BUFFER, 0, len(vertices)*4, gl.Ptr(vertices)) // Be sure to use glBufferSubData and not glBufferData
 		// Render quad
-		gl.DrawArrays(gl.TRIANGLES, 0, 16)
+		gl.DrawArrays(gl.TRIANGLES, 0, 6)
 
 		gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)

--- a/font.go
+++ b/font.go
@@ -119,23 +119,15 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		ypos := y - float32(ch.height-ch.bearingV)*scale
 		w := float32(ch.width) * scale
 		h := float32(ch.height) * scale
+		vertices := []float32{
+			xpos + w, yPos, 1.0, 0.0,
+			xpos, ypos, 0.0, 0.0,
+			xpos, ypos + h, 0.0, 1.0,
 
-		//set quad positions
-		var x1 = xpos
-		var x2 = xpos + w
-		var y1 = ypos
-		var y2 = ypos + h
-
-		//setup quad array
-		var vertices = []float32{
-			//  X, Y, Z, U, V
-			// Front
-			x1, y1, 0.0, 0.0,
-			x2, y1, 1.0, 0.0,
-			x1, y2, 0.0, 1.0,
-			x1, y2, 0.0, 1.0,
-			x2, y1, 1.0, 0.0,
-			x2, y2, 1.0, 1.0}
+			xpos, ypos + h, 0.0, 1.0,
+			xpos + w, ypos + h, 1.0, 1.0,
+			xpos + w, ypos, 1.0, 0.0,
+		}
 
 		// Render glyph texture over quad
 		gl.BindTexture(gl.TEXTURE_2D, ch.textureID)

--- a/shader.go
+++ b/shader.go
@@ -1,7 +1,7 @@
 package glfont
 
 import (
-	"github.com/go-gl/gl/all-core/gl"
+	"github.com/go-gl/gl/v4.1-core/gl"
 
 	"fmt"
 	"strings"
@@ -67,7 +67,7 @@ func compileShader(source string, shaderType uint32) (uint32, error) {
 	return shader, nil
 }
 
-var fragmentFontShader = `#version 150 core
+var fragmentFontShader = `#version 410 core
 in vec2 fragTexCoord;
 out vec4 outputColor;
 
@@ -80,7 +80,7 @@ void main()
     outputColor = textColor * sampled;
 }` + "\x00"
 
-var vertexFontShader = `#version 150 core
+var vertexFontShader = `#version 410 core
 
 //vertex position
 in vec2 vert;

--- a/truetype.go
+++ b/truetype.go
@@ -2,7 +2,8 @@ package glfont
 
 import (
 	"fmt"
-	"github.com/go-gl/gl/all-core/gl"
+
+	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/golang/freetype"
 	"github.com/golang/freetype/truetype"
 	"golang.org/x/image/font"


### PR DESCRIPTION
As of now the library does not work with ```gl.Enable(gl.CULL_FACE)```. This updates the vertices to be in the right order to be seen as front facing polygons so that they still get rendered and not culled.

You can see an example here of this behavior here. Using the old import path would render nothing at all.

[https://github.com/NicholasBlaskey/go-learn-opengl/blob/master/src/7.in_practice/2.text_rendering/test.go](https://github.com/NicholasBlaskey/go-learn-opengl/blob/master/src/7.in_practice/2.text_rendering/test.go).

